### PR TITLE
Add basic proxy relation

### DIFF
--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -62,6 +62,12 @@ def cluster_relation_changed():
     main(cluster_data)
 
 
+@hooks.hook('proxy-relation-changed')
+def proxy_relation_changed():
+    hookenv.relation_set(hookenv.relation_id(),
+                         {'cluster': cluster_string()})
+
+
 def main(cluster_data={}):
 
     # Grab the boilerplate config entries

--- a/hooks/proxy-relation-changed
+++ b/hooks/proxy-relation-changed
@@ -1,0 +1,1 @@
+hooks.py

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,6 +24,8 @@ maintainers:
 provides:
   client:
     interface: etcd
+  proxy:
+    interface: etcd-proxy
 peers:
   cluster:
     interface: etcd-raft


### PR DESCRIPTION
For Project Calico's OpenStack charms, we deploy etcd proxies on every node. These need access to the cluster token in order to function correctly, but they aren't raft peers. Rather than join on the cluster relation, it seemed like the better idea was to create a new relation expressly for proxies.

I have not yet tested this, but I wanted to open for review feedback as soon as possible.
