### PR TITLE
Changed `source` config option to `bin-source` to prevent

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 options:
-  source:
+  bin-source:
     type: string
     default: https://github.com/coreos/etcd/releases/download/v2.0.11/etcd-v2.0.11-linux-amd64.tar.gz
     description: Location of etcd binary release to fetch

--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -130,7 +130,7 @@ def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
 
 
 def install_etcd():
-    source = hookenv.config('source')
+    source = hookenv.config('bin-source')
     sha = hookenv.config('source-sum')
 
     unpack = fetch.install_remote(source, 'fetched', sha)


### PR DESCRIPTION
collisions with OpenStack OIL conventions.

https://bugs.launchpad.net/charms/+source/etcd/+bug/1478121
