### PR TITLE
is_leader requires juju 1.22.0 or better

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,16 @@ Health of the cluster can be checked by verified via juju actions
     juju action fetch <uuid>
 
 
+## Usage Caveats
+
+This charm requires Leader Election, which is a feature of Juju >= 1.23.2. The
+charm will panic and refuse to continue if the leader_election binary is not
+found. Please take care when deploying this charm on older versions of Juju.
+
 ## Credits
 
 The etcd charm was originally written by Kapil Thangavelu ([@kapilt](https://github.com/kapilt)).
+
 
 #### Mantainers: 
 

--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -8,7 +8,6 @@ from os import environ
 from path import path
 import string
 import random
-import semver
 import shlex
 from subprocess import check_output, check_call
 import sys
@@ -25,8 +24,8 @@ unit_name = environ['JUJU_UNIT_NAME'].replace('/', '')
 
 @hooks.hook('config-changed')
 def config_changed():
-    if not version_check:
-        hookenv.log('This charm requires juju 1.22.0 or greater. Panic and exit!'
+    if not isleader_available:
+        hookenv.log('This charm requires Juju 1.22.0 or greater. Panic and exit!'
                      'CRITICAL')
         sys.exit(1)
     if not db.get('installed') or hookenv.config().changed('source-sum'):
@@ -157,9 +156,22 @@ def install_etcd():
     hookenv.open_port(4001)
     db.set('installed', True)
 
-def version_check():
-    version = check_output(["juju", "--version"])
-    return semver.match(version, ">=1.22.0")
+def isleader_available():
+    """Attempt to locate is_leader
+
+    predicate method to determine if we are on a Juju revision that maintains
+    the leader election codebase.
+    """
+    cmd = ['which', 'is_leader']
+    try:
+        ret = subprocess.call(cmd, universal_newlines=True)
+        if ret == 0:
+            return True
+        else:
+            return False
+    except OSError as e:
+        # If we aren't finding the which command, we have bigger issues.
+            raise
 
 if __name__ == '__main__':
     with hook_data():

--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -23,7 +23,8 @@ unit_name = environ['JUJU_UNIT_NAME'].replace('/', '')
 try:
     leader_status = hookenv.is_leader()
 except NotImplementedError:
-    hookenv.log('This charm requires Juju 1.22.0 or greater. Panic and exit!'
+    hookenv.log('This charm requires Leader Election. Juju >= 1.23.2.'
+                ' Leader election binary not found, Panic and exit!',
                 'CRITICAL')
     sys.exit(1)
 

--- a/hooks/install
+++ b/hooks/install
@@ -5,7 +5,7 @@ set -ex
 # corrected and easy_install is no longer required to make pip function.
 # apt-get install -y python-pip
 easy_install -U pip
-pip install charmhelpers path.py requests semver
+pip install charmhelpers path.py requests
 
 echo "Creating etcd data path on $JUJU_UNIT_NAME"
 mkdir -p /opt/etcd/var

--- a/hooks/install
+++ b/hooks/install
@@ -5,7 +5,7 @@ set -ex
 # corrected and easy_install is no longer required to make pip function.
 # apt-get install -y python-pip
 easy_install -U pip
-pip install charmhelpers path.py requests
+pip install charmhelpers path.py requests semver
 
 echo "Creating etcd data path on $JUJU_UNIT_NAME"
 mkdir -p /opt/etcd/var


### PR DESCRIPTION
The ETCD charm fails with a non committal error message when probing for
is_leader on juju versions <= 1.21, 1.18 is still the default shipping
in universe, and will cause some headaches if users of older juju
versions attempt to use this charm as its leveraging the leader election
components.

There is probably a charm helper for consuming these methods that has a
sane fallback strategy, but for now this will satisfy the requirement of
blocking installation on anything < 1.22.0

Introduces a new dependency 'semver' to perform the version calculation
