### PR TITLE
Updates the template to include a local host bind

### DIFF
--- a/templates/etcd.conf.jinja2
+++ b/templates/etcd.conf.jinja2
@@ -11,7 +11,7 @@ kill timeout 60 # wait 60s between SIGTERM and SIGKILL.
 exec /opt/etcd/etcd \
         --initial-advertise-peer-urls http://{{private_address}}:7001 \
         --listen-peer-urls http://{{private_address}}:7001 \
-        --listen-client-urls http://{{private_address}}:4001 \
+        --listen-client-urls http://127.0.0.1:4001,http://{{private_address}}:4001 \
         --advertise-client-urls http://{{private_address}}:4001 \
         --initial-cluster-token {{token}} \
         --initial-cluster-state {{cluster_state}} \


### PR DESCRIPTION
We dont wish to expose ETCD to the public interface, however the etcd
utlity appears to default to wanting to communicate over 127.0.0.1:4001.
It does expose the -C and --peers option to reconfigure itself to
communicate with a peer on the given ip:port combination, but this
breaks user expectation of things "just working".

This fix adjusts the binding which can be verified via netstat -nlp that
hte service is only listening on private address, and the adveritsing to
the API/Peers only displays the private address, while allowing the
etcdctl client to communicate using the localhost binding default.
