### PR TITLE
Pin the package of path.py to prevent breakage

### DIFF
--- a/hooks/install
+++ b/hooks/install
@@ -5,7 +5,7 @@ set -ex
 # corrected and easy_install is no longer required to make pip function.
 # apt-get install -y python-pip
 easy_install -U pip
-pip install charmhelpers path.py requests
+pip install -r $CHARM_DIR/requirements.txt
 
 echo "Creating etcd data path on $JUJU_UNIT_NAME"
 mkdir -p /opt/etcd/var

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+charmhelpers
+path.py <=  7.7.1
+requests
+


### PR DESCRIPTION
Due to bug 102 https://github.com/jaraco/path.py/issues/102 path.py was
recently updated to remove an alias of "path" and this breaks thing in a
big way which warranted moving from inline dependency statements to
tracking deps.

This may not be an immediate issue anymore, but we're better off
tracking dependencies in a requirements.txt so we can mitigate design
changes like this moving forward
